### PR TITLE
Add vagrant instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ git clone https://github.com/brendangregg/bpf-perf-workshop
 vagrant up
 ```
 
+After Vagrant finishes, the repo content will be located under
+/home/vagrant/bpf-perf-workshop
+
 
 Just for reference, you can fetch these repos:
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ You can either:
 
 - SSH to a lab instance (see bit of paper), or,
 - Setup your own system with [BCC](https://github.com/iovisor/bcc) & [bpftrace](https://github.com/iovisor/bpftrace). Sample instructions below.
+- Use the supplied Vagrant box (https://www.vagrantup.com/downloads.html)
 
 #### System Setup
 
-If you choose to setup your own system, here is a script for Ubuntu:
+##### Local setup
+
+If you choose to setup your own system, here is a script for Ubuntu: (19.04 or greater required)
 
 ```
 sudo apt-get update
@@ -24,6 +27,14 @@ git clone https://github.com/brendangregg/bpf-perf-workshop
 cd bpf-perf-workshop/src
 make && cd ..
 ```
+
+##### Using Vagrant
+
+```
+git clone https://github.com/brendangregg/bpf-perf-workshop
+vagrant up
+```
+
 
 Just for reference, you can fetch these repos:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,72 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/focal64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+   config.vm.provision "shell", inline: <<-SHELL
+     sudo apt-get update
+     sudo apt-get install -y sysstat bpfcc-tools bpftrace gcc
+     git clone https://github.com/brendangregg/bpf-perf-workshop.git /home/vagrant/bpf-perf-workshop
+   SHELL
+end


### PR DESCRIPTION
Since the `ubuntu` options only work with newer versions of ubuntu (>=19.04) I thought it was a good idea to provide a Vagrant box to go through this. I believe it might be useful for the community also.
